### PR TITLE
pom: update flusswerk version to 4.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.github.dbmdz.flusswerk</groupId>
     <artifactId>flusswerk</artifactId>
-    <version>4.0.0</version>
+    <version>4.1.1</version>
   </parent>
 
   <properties>


### PR DESCRIPTION
PR updates version of `flusswerk` to latest *4.1.1*:

```bash
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ example ---
[INFO] com.github.dbmdz.flusswerk:example:jar:1.0-SNAPSHOT
[INFO] +- com.github.dbmdz.flusswerk:framework:jar:4.1.1:compile
```